### PR TITLE
update example and readme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-latest, windows-latest]
-        python-version: [3.9, '3.10', '3.11', '3.12', '3.13']
+        python-version: [3.9, '3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
     - name: Set git crlf/eol
       run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9, '3.10', '3.11', '3.12', '3.13']
+        python-version: [3.9, '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - name: Set git crlf/eol

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -1,4 +1,3 @@
-import codecs
 import logging
 from pathlib import Path
 
@@ -28,11 +27,13 @@ log_str = """
 
 
 class TLogWatcher(LogWatcher):
-    """Override ``open()`` to decode log lines"""
+    """
+    Overriding ``open()`` for decoding may lead to issues in newer Python
+    """
 
     @classmethod
     def open(cls, file):
-        return codecs.open(file, 'r', encoding="utf-8", errors='ignore')
+        return open(file, 'rb')
 
 
 def loop_callback(filename, lines):
@@ -61,7 +62,7 @@ def test_log_watcher_tail(caplog, tmp_path):
     assert "Watching logfile" in caplog.text
     print(caplog.text)
     for line in lines:
-        assert isinstance(line, str)
+        assert isinstance(line, bytes)
     print(f'\n{lines}')
 
 


### PR DESCRIPTION
* open log files in binary mode only (avoid problems in newer python versions)
* update consumer test and subclass, add py3.14 to matrix workflows